### PR TITLE
feat(core): add foundational models and services

### DIFF
--- a/appstories/Package.swift
+++ b/appstories/Package.swift
@@ -7,12 +7,21 @@ let package = Package(
         .macOS(.v13)
     ],
     products: [
-        .library(name: "TaskRunner", targets: ["TaskRunner"])
+        .library(name: "TaskRunner", targets: ["TaskRunner"]),
+        .library(name: "StoryCore", targets: ["StoryCore"])
     ],
     targets: [
         .target(
             name: "TaskRunner",
             dependencies: []
+        ),
+        .target(
+            name: "StoryCore",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "StoryCoreTests",
+            dependencies: ["StoryCore"]
         )
     ]
 )

--- a/appstories/Sources/StoryCore/Models/Project.swift
+++ b/appstories/Sources/StoryCore/Models/Project.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct Project: Codable {
+    public struct UserInput: Codable {
+        public var topic: String
+        public var tone: String
+        public var minutes: Int
+        public var language: String
+
+        public init(topic: String, tone: String, minutes: Int, language: String) {
+            self.topic = topic
+            self.tone = tone
+            self.minutes = minutes
+            self.language = language
+        }
+    }
+
+    public struct TTSConfig: Codable {
+        public var provider: String
+        public var voice: String
+        public var speed: Double
+        public var pitch: Double
+
+        public init(provider: String, voice: String, speed: Double = 1.0, pitch: Double = 0.0) {
+            self.provider = provider
+            self.voice = voice
+            self.speed = speed
+            self.pitch = pitch
+        }
+    }
+
+    public var title: String
+    public var createdAt: Date
+    public var userInput: UserInput
+    public var providerLLM: String
+    public var providerImages: String
+    public var tts: TTSConfig
+    public var render: RenderProfile
+    public var useAspectParam: Bool
+
+    public init(title: String,
+                createdAt: Date = Date(),
+                userInput: UserInput,
+                providerLLM: String,
+                providerImages: String,
+                tts: TTSConfig,
+                render: RenderProfile,
+                useAspectParam: Bool = true) {
+        self.title = title
+        self.createdAt = createdAt
+        self.userInput = userInput
+        self.providerLLM = providerLLM
+        self.providerImages = providerImages
+        self.tts = tts
+        self.render = render
+        self.useAspectParam = useAspectParam
+    }
+}

--- a/appstories/Sources/StoryCore/Models/ProvidersConfig.swift
+++ b/appstories/Sources/StoryCore/Models/ProvidersConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct ProvidersConfig: Codable {
+    public var llm: String
+    public var images: String
+    public var tts: String
+
+    public init(llm: String, images: String, tts: String) {
+        self.llm = llm
+        self.images = images
+        self.tts = tts
+    }
+}

--- a/appstories/Sources/StoryCore/Models/RenderProfile.swift
+++ b/appstories/Sources/StoryCore/Models/RenderProfile.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct RenderProfile: Codable {
+    public var aspect: String
+    public var resolution: String
+    public var fps: Int
+    public var subtitles: Bool
+
+    public init(aspect: String, resolution: String, fps: Int = 30, subtitles: Bool = true) {
+        self.aspect = aspect
+        self.resolution = resolution
+        self.fps = fps
+        self.subtitles = subtitles
+    }
+}

--- a/appstories/Sources/StoryCore/Models/Scene.swift
+++ b/appstories/Sources/StoryCore/Models/Scene.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct Scene: Codable, Identifiable {
+    public var index: Int
+    public var start: String
+    public var end: String
+    public var durationSec: Double
+    public var imagePrompt: String
+
+    public var id: Int { index }
+
+    public init(index: Int, start: String, end: String, durationSec: Double, imagePrompt: String) {
+        self.index = index
+        self.start = start
+        self.end = end
+        self.durationSec = durationSec
+        self.imagePrompt = imagePrompt
+    }
+}

--- a/appstories/Sources/StoryCore/Models/Timeline.swift
+++ b/appstories/Sources/StoryCore/Models/Timeline.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Timeline: Codable {
+    public var version: String
+    public var aspect: String
+    public var fps: Int
+    public var scenes: [Scene]
+
+    public init(version: String = "1.1", aspect: String, fps: Int = 30, scenes: [Scene]) {
+        self.version = version
+        self.aspect = aspect
+        self.fps = fps
+        self.scenes = scenes
+    }
+}

--- a/appstories/Sources/StoryCore/Services/FileSystemService.swift
+++ b/appstories/Sources/StoryCore/Services/FileSystemService.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct FileSystemService {
+    private let fm: FileManager
+
+    public init(fileManager: FileManager = .default) {
+        self.fm = fileManager
+    }
+
+    @discardableResult
+    public func createDirectory(at url: URL) throws -> URL {
+        try fm.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        return url
+    }
+
+    public func fileExists(at url: URL) -> Bool {
+        fm.fileExists(atPath: url.path)
+    }
+
+    public func write<T: Encodable>(_ value: T, to url: URL) throws {
+        let data = try JSONEncoder().encode(value)
+        try createDirectory(at: url.deletingLastPathComponent())
+        try data.write(to: url, options: .atomic)
+    }
+
+    public func read<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/appstories/Sources/StoryCore/Services/Logger.swift
+++ b/appstories/Sources/StoryCore/Services/Logger.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public actor Logger {
+    public enum Level: String, Codable {
+        case debug, info, warning, error
+    }
+
+    private let logURL: URL
+    private let fm: FileManager
+    private let encoder = JSONEncoder()
+
+    public init(logURL: URL, fileManager: FileManager = .default) {
+        self.logURL = logURL
+        self.fm = fileManager
+        try? fm.createDirectory(at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    }
+
+    public func log(_ message: String, level: Level = .info, category: String? = nil) {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        var dict: [String: String] = [
+            "ts": ts,
+            "level": level.rawValue,
+            "message": message
+        ]
+        if let category { dict["category"] = category }
+        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+              var line = String(data: data, encoding: .utf8) else { return }
+        line.append("\n")
+        if fm.fileExists(atPath: logURL.path) {
+            if let handle = try? FileHandle(forWritingTo: logURL) {
+                do {
+                    try handle.seekToEnd()
+                    if let d = line.data(using: .utf8) {
+                        try handle.write(contentsOf: d)
+                    }
+                    try handle.close()
+                } catch {
+                    try? handle.close()
+                }
+            }
+        } else {
+            try? line.write(to: logURL, atomically: true, encoding: .utf8)
+        }
+    }
+}

--- a/appstories/Tests/StoryCoreTests/FileSystemServiceTests.swift
+++ b/appstories/Tests/StoryCoreTests/FileSystemServiceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import StoryCore
+
+final class FileSystemServiceTests: XCTestCase {
+    func testWriteAndReadProject() throws {
+        let service = FileSystemService()
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let url = tempDir.appendingPathComponent("project.json")
+        let project = Project(
+            title: "Test",
+            userInput: .init(topic: "topic", tone: "tone", minutes: 1, language: "ru"),
+            providerLLM: "grok",
+            providerImages: "openai",
+            tts: .init(provider: "avspeech", voice: "ru"),
+            render: RenderProfile(aspect: "9:16", resolution: "1080x1920")
+        )
+        try service.write(project, to: url)
+        let loaded: Project = try service.read(Project.self, from: url)
+        XCTAssertEqual(loaded.title, project.title)
+    }
+}

--- a/appstories/Tests/StoryCoreTests/LoggerTests.swift
+++ b/appstories/Tests/StoryCoreTests/LoggerTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import StoryCore
+
+final class LoggerTests: XCTestCase {
+    func testLogAppendsToFile() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let logURL = dir.appendingPathComponent("pipeline.log")
+        let logger = Logger(logURL: logURL)
+        await logger.log("hello", level: .info, category: "TEST")
+        let text = try String(contentsOf: logURL)
+        XCTAssertTrue(text.contains("hello"))
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Project, Scene, RenderProfile and other core models
- add FileSystemService and asynchronous Logger
- configure StoryCore target with unit tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68af1fddf180833094fe313f7dd46f59